### PR TITLE
Origin/feature/poisonshadereffect

### DIFF
--- a/Assets/Scenes/Level1/Room1.unity
+++ b/Assets/Scenes/Level1/Room1.unity
@@ -3988,6 +3988,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4065599693243427795, guid: 6033645b16414654f8ea4c4c72eda2f8, type: 3}
+      propertyPath: waterMaterial
+      value: 
+      objectReference: {fileID: 2100000, guid: 68d4a88ca7fe4234e9d169a2ad47b5e0, type: 2}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/Assets/Scenes/Materials/HazardMaterials/WaterShaderMaterial.mat
+++ b/Assets/Scenes/Materials/HazardMaterials/WaterShaderMaterial.mat
@@ -39,15 +39,15 @@ Material:
     m_Floats:
     - _QueueControl: 0
     - _QueueOffset: 0
-    - _opacity: 0.9
-    - _rippleDensity: 5
+    - _opacity: 0.8
+    - _rippleDensity: 10
     - _rippleSlimness: 5
-    - _rippleSpeed: 1
-    - _waveSpeed: 0.1
+    - _rippleSpeed: 4
+    - _waveSpeed: 0.2
     - _waveStrength: 5
     m_Colors:
-    - _baseColor: {r: 0, g: 0.4528302, b: 0.019904623, a: 0}
-    - _rippleColor: {r: 0.24395734, g: 1, b: 0.15566039, a: 0}
+    - _baseColor: {r: 0, g: 0.35849056, b: 0.0166357, a: 0}
+    - _rippleColor: {r: 0.061118998, g: 0.5999999, b: 0, a: 0}
   m_BuildTextureStacks: []
 --- !u!114 &7000772178026502927
 MonoBehaviour:

--- a/Assets/Scenes/Materials/UIMaterials/GammarMaterial.mat
+++ b/Assets/Scenes/Materials/UIMaterials/GammarMaterial.mat
@@ -65,7 +65,7 @@ Material:
     - _Cutoff: 0.5
     - _DetailNormalMapScale: 1
     - _DstBlend: 0
-    - _Gamma: 1.0026937
+    - _Gamma: 1
     - _GlossMapScale: 1
     - _Glossiness: 0.5
     - _GlossyReflections: 1

--- a/Assets/Scripts/FMOD/SoundManager.cs
+++ b/Assets/Scripts/FMOD/SoundManager.cs
@@ -69,7 +69,7 @@ public class SoundManager : MonoBehaviour
         EnemyController[] enemyControllers = FindObjectsOfType<EnemyController>();
         foreach (EnemyController enemyController in enemyControllers) {
             enemyController.PauseAudio(pause);
-            Debug.Log("Enemy sound has been paused: " + pause);
+            //Debug.Log("Enemy sound has been paused: " + pause);
         }
     }
 

--- a/Assets/Scripts/Hazard/FlowingWater/FlowingWater.cs
+++ b/Assets/Scripts/Hazard/FlowingWater/FlowingWater.cs
@@ -39,6 +39,19 @@ namespace Hazard
         [Tooltip("The damage which the KillArea deals.")]
         [SerializeField] private float _damage = 999;
 
+        [Header("Shader Speed")]
+        [Tooltip("The speed of the shader effect on the poison.")]
+        [SerializeField] private float slowWaveSpeed = 0.1f;
+        [SerializeField] private float mediumWaveSpeed = 0.2f;
+        [SerializeField] private float fastWaveSpeed = 0.5f;
+        [SerializeField] private float slowRippleSpeed = 1.0f;
+        [SerializeField] private float mediumRippleSpeed = 2.0f;
+        [SerializeField] private float fastRippleSpeed = 5.0f;
+        [SerializeField] private float slowRippleDensity = 10f;
+        [SerializeField] private float mediumRippleDensity = 12f;
+        [SerializeField] private float fastRippleDensity = 15f;
+
+        [SerializeField] private Material waterMaterial;
         private Coroutine resetWaterCoroutine;
 
         public void Awake()
@@ -79,16 +92,41 @@ namespace Hazard
             // Ensure the exact target position is set
             killArea.transform.position = targetPosition;
         }
+        private IEnumerator ChangeMaterialDensity(float targetRippleSpeed, float targetWaveSpeed, float targetRippleDensity)
+        {
+            // Change the material properties over time
+            float elapsedTime = 0f;
+            float initialRippleSpeed = waterMaterial.GetFloat("_RippleSpeed");
+            float initialWaveSpeed = waterMaterial.GetFloat("_WaveSpeed");
+            float initialRippleDensity = waterMaterial.GetFloat("_RippleDensity");
 
+            while (elapsedTime < _duration)
+            {
+                float t = elapsedTime / _duration;
+
+                waterMaterial.SetFloat("_RippleSpeed", Mathf.Lerp(initialRippleSpeed, targetRippleSpeed, t));
+                waterMaterial.SetFloat("_WaveSpeed", Mathf.Lerp(initialWaveSpeed, targetWaveSpeed, t));
+                waterMaterial.SetFloat("_RippleDensity", Mathf.Lerp(initialRippleDensity, targetRippleDensity, t));
+
+                elapsedTime += Time.deltaTime;
+                yield return null;
+            }
+
+            // Ensure the exact target values are set
+            waterMaterial.SetFloat("_RippleSpeed", targetRippleSpeed);
+            waterMaterial.SetFloat("_WaveSpeed", targetWaveSpeed);
+            waterMaterial.SetFloat("_RippleDensity", targetRippleDensity);
+        }
         /**
          * Move the 'KillArea' depending on the TapeType.
          */
         public override void Affect(TapeType tapeType, float duration, float effectValue)
         {
-            if(tapeType == TapeType.Slow)
+            if (tapeType == TapeType.Slow)
             {
                 // Move the 'KillArea' object to height1.
                 StartCoroutine(MoveKillAreaToHeight(height1));
+                StartCoroutine(ChangeMaterialDensity(slowRippleSpeed, slowWaveSpeed, slowRippleDensity));
 
                 // Code for Animations and Sounds.
 
@@ -96,24 +134,31 @@ namespace Hazard
                 // then reset it.
                 if (resetWaterCoroutine != null) StopCoroutine(resetWaterCoroutine);
 
-                if (useDefaultEffectTimeValues) {
+                if (useDefaultEffectTimeValues)
+                {
                     resetWaterCoroutine = StartCoroutine(AffectTimer(duration));
-                } else {
+                }
+                else
+                {
                     resetWaterCoroutine = StartCoroutine(AffectTimer(_slowEffectTime));
                 }
             }
 
-            if(tapeType == TapeType.Fast)
+            if (tapeType == TapeType.Fast)
             {
                 // Move the 'KillArea' object to height1.
                 StartCoroutine(MoveKillAreaToHeight(height3));
+                StartCoroutine(ChangeMaterialDensity(fastRippleSpeed, fastWaveSpeed, fastRippleDensity));
 
                 // Code for Animations and Sounds.
                 if (resetWaterCoroutine != null) StopCoroutine(resetWaterCoroutine);
 
-                if (useDefaultEffectTimeValues) {
+                if (useDefaultEffectTimeValues)
+                {
                     resetWaterCoroutine = StartCoroutine(AffectTimer(duration));
-                } else {
+                }
+                else
+                {
                     resetWaterCoroutine = StartCoroutine(AffectTimer(_fastEffectTime));
                 }
             }
@@ -129,6 +174,8 @@ namespace Hazard
 
             // Move the 'KillArea' object to height3.
             StartCoroutine(MoveKillAreaToHeight(height2));
+            StartCoroutine(ChangeMaterialDensity(mediumRippleSpeed, mediumWaveSpeed, mediumRippleDensity));
         }
     }
+
 }

--- a/Assets/Scripts/Hazard/FlowingWater/FlowingWater.cs
+++ b/Assets/Scripts/Hazard/FlowingWater/FlowingWater.cs
@@ -52,6 +52,10 @@ namespace Hazard
         [SerializeField] private float fastRippleDensity = 15f;
 
         [SerializeField] private Material waterMaterial;
+        private static readonly int RippleSpeedID = Shader.PropertyToID("_rippleSpeed"),
+                                    WaveSpeedID = Shader.PropertyToID("_waveSpeed"),
+                                    RippleDensityID = Shader.PropertyToID("_rippleDensity");
+
         private Coroutine resetWaterCoroutine;
 
         public void Awake()
@@ -96,26 +100,26 @@ namespace Hazard
         {
             // Change the material properties over time
             float elapsedTime = 0f;
-            float initialRippleSpeed = waterMaterial.GetFloat("_RippleSpeed");
-            float initialWaveSpeed = waterMaterial.GetFloat("_WaveSpeed");
-            float initialRippleDensity = waterMaterial.GetFloat("_RippleDensity");
+            float initialRippleSpeed = waterMaterial.GetFloat(RippleSpeedID);
+            float initialWaveSpeed = waterMaterial.GetFloat(WaveSpeedID);
+            float initialRippleDensity = waterMaterial.GetFloat(RippleDensityID);
 
             while (elapsedTime < _duration)
             {
                 float t = elapsedTime / _duration;
 
-                waterMaterial.SetFloat("_RippleSpeed", Mathf.Lerp(initialRippleSpeed, targetRippleSpeed, t));
-                waterMaterial.SetFloat("_WaveSpeed", Mathf.Lerp(initialWaveSpeed, targetWaveSpeed, t));
-                waterMaterial.SetFloat("_RippleDensity", Mathf.Lerp(initialRippleDensity, targetRippleDensity, t));
+                waterMaterial.SetFloat(RippleSpeedID, Mathf.Lerp(initialRippleSpeed, targetRippleSpeed, t));
+                waterMaterial.SetFloat(WaveSpeedID, Mathf.Lerp(initialWaveSpeed, targetWaveSpeed, t));
+                waterMaterial.SetFloat(RippleDensityID, Mathf.Lerp(initialRippleDensity, targetRippleDensity, t));
 
                 elapsedTime += Time.deltaTime;
                 yield return null;
             }
 
             // Ensure the exact target values are set
-            waterMaterial.SetFloat("_RippleSpeed", targetRippleSpeed);
-            waterMaterial.SetFloat("_WaveSpeed", targetWaveSpeed);
-            waterMaterial.SetFloat("_RippleDensity", targetRippleDensity);
+            waterMaterial.SetFloat(RippleSpeedID, targetRippleSpeed);
+            waterMaterial.SetFloat(WaveSpeedID, targetWaveSpeed);
+            waterMaterial.SetFloat(RippleDensityID, targetRippleDensity);
         }
         /**
          * Move the 'KillArea' depending on the TapeType.

--- a/Assets/Shaders/Hazards/WaterShader.shadergraph
+++ b/Assets/Shaders/Hazards/WaterShader.shadergraph
@@ -1878,7 +1878,7 @@
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
     "m_Hidden": false,
-    "m_Value": 0.10000000149011612,
+    "m_Value": 0.5,
     "m_FloatType": 0,
     "m_RangeValues": {
         "x": 0.0,


### PR DESCRIPTION
adjust the logic in tape switch for acid water,  so the parameter of shader in material changes when switching tape. This allows the acid water to flow faster in a higher tempo. 
Introduced the slowWaveSpeed , mediumWaveSpeed,  fastWaveSpeed, slowRippleSpeed, mediumRippleSpeed, fastRippleSpeed, slowRippleDensity, mediumRippleDensity, fastRippleDensity parameters to manipulate the speed, corresponds to the paramter in the shader graph. 
