### PR TITLE
make the enemy initiate attack only on the beat

### DIFF
--- a/Assets/Prefabs/DamagePrefabs/CircleDamageArea.prefab
+++ b/Assets/Prefabs/DamagePrefabs/CircleDamageArea.prefab
@@ -19,7 +19,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &4976065253566315344
 Transform:
   m_ObjectHideFlags: 0
@@ -50,7 +50,7 @@ MeshRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3345562608605307880}
-  m_Enabled: 0
+  m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1

--- a/Assets/Scripts/Enemies/EnemyStates/AttackState.cs
+++ b/Assets/Scripts/Enemies/EnemyStates/AttackState.cs
@@ -5,19 +5,26 @@ using Enemy;
 using UnityEngine.AI;
 using Player;
 using Enemies.EnemyTypes;
+using System;
+using Timeline;
 
 public class AttackState : BaseEnemyState
 {
     protected float outsideAttackRangeTime;
     protected float outsideAttackRangeDuration = 0.5f;
-    
-    public AttackState(EnemyController enemyController, NavMeshAgent navMeshAgent, PlayerController playerController) : 
-                        base(enemyController, navMeshAgent, playerController) { }
+    private bool isSyncable;
+    public AttackState(EnemyController enemyController, NavMeshAgent navMeshAgent, PlayerController playerController) :
+                        base(enemyController, navMeshAgent, playerController)
+    { 
+        isSyncable = enemyController.IsSyncable;        
+    }
 
-    public override void EnterState() {
+    public override void EnterState()
+    {
         // Debug.Log("Entering Attack State");
-        
-        if(enemyController.GetAnimator()){
+
+        if (enemyController.GetAnimator())
+        {
             enemyController.GetAnimator().SetBool("AttackIdle", true);
         }
         navMeshAgent.SetDestination(enemyController.transform.position);
@@ -25,7 +32,8 @@ public class AttackState : BaseEnemyState
         outsideAttackRangeTime = outsideAttackRangeDuration;
     }
 
-    public override void UpdateState() {
+    public override void UpdateState()
+    {
         if (playerController != null)
             enemyController.transform.LookAt(playerController.transform.position);
 
@@ -33,32 +41,59 @@ public class AttackState : BaseEnemyState
         // attack to finish first.
         if (enemyController.IsAttacking()) return;
         // If the player was killed, transition to patrol state.
-        else if (!playerController) {
+        else if (!playerController)
+        {
             enemyController.TransitionToState(EnemyState.Patrol);
         }
         // If the player is too close to the enemy, the enemy must flee.
         // This is only if the enemy is a ranged enemy.
-        else if (enemyController is RangedEnemyController rController && rController.EnemyIsInFleeRange()) {
+        else if (enemyController is RangedEnemyController rController && rController.EnemyIsInFleeRange())
+        {
             enemyController.TransitionToState(EnemyState.Flee);
         }
         // If the player has exited attack range, transition to chase state
         // after some time.
-        else if (!enemyController.PlayerIsInAttackRange()) {
+        else if (!enemyController.PlayerIsInAttackRange())
+        {
             outsideAttackRangeTime -= Time.deltaTime;
-            if (outsideAttackRangeTime <= 0) {
+            if (outsideAttackRangeTime <= 0)
+            {
                 enemyController.TransitionToState(EnemyState.Chase);
             }
         }
-        // If all the above conditions are false, then attack the player
-        else {
+        // add the beat spawner check to syncronise the attack with the beat
+        else if ((!isSyncable || MusicTimeline.instance.onTempo) && !enemyController.IsAttacking())
+        {   
+            Debug.Log("Attacking player" + Time.time + " " + enemyController.gameObject.GetInstanceID());
             enemyController.Attack();
         }
     }
 
-    public override void ExitState() {
+    public override void ExitState()
+    {
         enemyController.GetAttackSound().stop(FMOD.Studio.STOP_MODE.ALLOWFADEOUT);
-        if(enemyController.GetAnimator()){
+        if (enemyController.GetAnimator())
+        {
             enemyController.GetAnimator().SetBool("AttackIdle", false);
-        }    
+        }
     }
+    private BeatSpawner beatSpawner;
+
+    public BeatSpawner BeatSpawner
+    {
+        get
+        {
+            if (beatSpawner == null)
+            {
+                beatSpawner = GameManager.Instance.BeatSpawner;
+                if (beatSpawner == null)
+                {
+                    throw new Exception("No BeatSpawner found in the scene. please attach to somewhere in the scene");
+                }
+            }
+            return beatSpawner;
+
+        }
+    }
+
 }

--- a/Assets/Scripts/Enemies/EnemyTypes/EliteEnemyController.cs
+++ b/Assets/Scripts/Enemies/EnemyTypes/EliteEnemyController.cs
@@ -54,17 +54,14 @@ namespace Enemies.EnemyTypes
         {
             if (canAttack)
             {
-                if (!IsAttacking())
-                {
-                    // Visual effect to show the enemy is not guarding.
-                    guardIndicator.SetActive(false);
+                // Visual effect to show the enemy is not guarding.
+                guardIndicator.SetActive(false);
 
-                    // When elite enemy starts attacking, it can be damaged.
-                    damageable.setIsInvulnerable(false);
-                    // Set isTrigger to true so player or other enemies can pass through.
-                    enemyCollider.isTrigger = true;
-                    base.Attack();
-                }
+                // When elite enemy starts attacking, it can be damaged.
+                damageable.setIsInvulnerable(false);
+                // Set isTrigger to true so player or other enemies can pass through.
+                enemyCollider.isTrigger = true;
+                base.Attack();
             }
         }
 

--- a/Assets/Scripts/Enemies/EnemyTypes/EnemyController.cs
+++ b/Assets/Scripts/Enemies/EnemyTypes/EnemyController.cs
@@ -22,7 +22,13 @@ namespace Enemy
         protected NavMeshAgent agent;
 
         [SerializeField] private float health = 100f;
-
+        [Tooltip("Will the enemy be synced with the beat?")]
+        [SerializeField] private bool isSyncable = true;
+        public bool IsSyncable
+        {
+            get => isSyncable;
+            set => isSyncable = value;
+        }
         // Idle Variables
         [Header("Idle Variables")]
         [Tooltip("How long the enemy will idle before switching to patrol states.")]

--- a/Assets/Scripts/Enemies/EnemyTypes/MeleeEnemyController.cs
+++ b/Assets/Scripts/Enemies/EnemyTypes/MeleeEnemyController.cs
@@ -30,16 +30,14 @@ namespace Enemies.EnemyTypes
         
         public override void Attack()
         {
-            if (!IsAttacking())
-            {   
-                if (GetAnimator()){
-                    animator.SetTrigger("Attack");
-                }
-
-                SetIsAttacking(true);
-                StartStrike();
+            if (GetAnimator()){
+                animator.SetTrigger("Attack");
             }
+
+            SetIsAttacking(true);
+            StartStrike();
         }
+        
 
         private void StartStrike()
         {

--- a/Assets/Scripts/Enemies/EnemyTypes/RangedEnemyController.cs
+++ b/Assets/Scripts/Enemies/EnemyTypes/RangedEnemyController.cs
@@ -65,8 +65,6 @@ namespace Enemies.EnemyTypes
         
         #region Attack
         public override void Attack() {
-            if (!IsAttacking())
-            {
                 // Trigger animation
                 // GetAnimator().SetTrigger(GetAttackAnimationTrigger());
 
@@ -89,7 +87,6 @@ namespace Enemies.EnemyTypes
                 //StudioEventEmitter fire = GetComponent<FMODUnity.StudioEventEmitter>();
                 //fire.Play();
                 //FMODUnity.RuntimeManager.AttachInstanceToGameObject(fire.EventInstance, gameObject, GetComponent<Rigidbody>());
-            }
         }
 
         private IEnumerator PerformStrikeSequence()

--- a/Assets/Scripts/FMOD/ScriptMusicTimeline.cs
+++ b/Assets/Scripts/FMOD/ScriptMusicTimeline.cs
@@ -66,7 +66,7 @@ namespace Timeline
 
         static bool beatTrigger = false;
         static float beatWindowAfter;
-
+        public bool onTempo = false;
         [SerializeField] private float _volume = 1.0f;
 
     #if UNITY_EDITOR
@@ -102,18 +102,23 @@ namespace Timeline
         }
 
         void Update() {
+            if (onTempo) onTempo = false;
+            
             // Wait for some time before spawning beats each time the tempo changes
-            if (currentTempo != timelineInfo.CurrentMusicTempo) {
+            if (currentTempo != timelineInfo.CurrentMusicTempo)
+            {
                 currentChangeTempoTime = changeTempoDuration;
                 currentTempo = timelineInfo.CurrentMusicTempo;
             }
 
             currentChangeTempoTime -= Time.deltaTime;
             if (currentChangeTempoTime <= 0) {
-                if (toSpawnBeat) {
+                if (toSpawnBeat)
+                {
                     toSpawnBeat = false;
                     beatSpawner.SetTempo(currentTempo);
                     beatSpawner.SpawnBeat();
+                    onTempo = true;
                 }
             } else {
                 toSpawnBeat = false;

--- a/Assets/Scripts/FMOD/SoundManager.cs
+++ b/Assets/Scripts/FMOD/SoundManager.cs
@@ -78,7 +78,7 @@ public class SoundManager : MonoBehaviour
         EnemyController[] enemyControllers = FindObjectsOfType<EnemyController>();
         foreach (EnemyController enemyController in enemyControllers) {
             enemyController.StopSFX();
-            Debug.Log("Enemy sound has been stopped!");
+            //Debug.Log("Enemy sound has been stopped!");
         }
     }
 }

--- a/Assets/Scripts/UI/Beat/Beat.cs
+++ b/Assets/Scripts/UI/Beat/Beat.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
 
 public class Beat : MonoBehaviour
@@ -8,14 +9,16 @@ public class Beat : MonoBehaviour
     private RectTransform targetPos;
     private float travelTime;  // How much time to travel to the hexagon
     private float hitTolerance;  // How close it needs to be to the target to count as a hit
-
-    public void Initialise(TargetHexagon hexagon, float beatTravelTime, float hitDistanceTolerance)
+    private bool hitted = false;  // Whether the beat has been hit or not
+    private Queue<Beat> queue;  // Reference to the BeatSpawner
+    public void Initialise(TargetHexagon hexagon, float beatTravelTime, float hitDistanceTolerance, Queue<Beat> queue)
     {
         rectTransform = GetComponent<RectTransform>();
         targetHexagon = hexagon;
         targetPos = targetHexagon.gameObject.GetComponent<RectTransform>();
         travelTime = beatTravelTime;
         hitTolerance = hitDistanceTolerance;
+        this.queue = queue;
         StartCoroutine(MoveToLine());
     }
 
@@ -41,19 +44,22 @@ public class Beat : MonoBehaviour
             rectTransform.anchoredPosition = Vector3.Lerp(startPos, endPos, elapsedTime / travelTime);
             yield return null;
         }
-
         // If the beat has reached its end position, this means the player missed
-        OnMiss();
+        if (!hitted) OnMiss();
+
     }
 
-    public bool IsHittable()
+    public bool IsHittable(float tolerance = 0.0f)
     {
         if (!rectTransform) return false;
 
         // x pos of the beat and its target
         float beatX = rectTransform.anchoredPosition.x;
         float targetX = targetPos.anchoredPosition.x;
-
+        if (tolerance > 0.0f)
+        {
+            return Mathf.Abs(beatX - targetX) <= tolerance;
+        }
         return Mathf.Abs(beatX - targetX) <= hitTolerance;
     }
 
@@ -61,6 +67,8 @@ public class Beat : MonoBehaviour
     {
         // Call the method to change the hexagon's color temporarily
         if (targetHexagon != null) targetHexagon.ChangeColorTemporary(true);
+        hitted = true;  // Mark the beat as hit
+        queue.Dequeue();  // Remove the beat from the queue
         Destroy(gameObject);  // Remove beat after it was hit
 
         // can add more feedback (e.g., score increment, sound effect)
@@ -68,10 +76,11 @@ public class Beat : MonoBehaviour
 
     public void OnMiss()
     {
+        queue.Dequeue();  // Remove the beat from the queue
+
         // Call the method to change the hexagon's color temporarily
         if (targetHexagon != null) targetHexagon.ChangeColorTemporary(false);
         Destroy(gameObject);  // Remove beat
-
         // can add more feedback (e.g., score increment, sound effect)
     }
 }

--- a/Assets/Scripts/UI/Beat/BeatSpawner.cs
+++ b/Assets/Scripts/UI/Beat/BeatSpawner.cs
@@ -10,7 +10,9 @@ public class BeatSpawner : MonoBehaviour
     public Transform spawnPointRight;  // Where beats spawn on the right
     public Transform hexagonLeft;  // Beats spawning on the left move to this
     public Transform hexagonRight;  // Beats spawning on the right move to this
-    private List<Beat> beats = new();  // Stores the active beats
+    private Queue<Beat> beatQueueLeft = new();  // Queue for beats to be processed
+    private Queue<Beat> beatQueueRight = new();  // Queue for beats to be processed
+
     private float beatTravelTime;  // Time for the beat to move from its start to end pos
 
     [Tooltip("Hit range to hit beats on time")]
@@ -34,34 +36,33 @@ public class BeatSpawner : MonoBehaviour
         GameObject beatLeft = Instantiate(beatPrefab, spawnPointLeft.position, Quaternion.identity, transform);
         // Should be the same as parent's rotation otherwise it will be out of shape
         beatLeft.transform.rotation = transform.rotation;
-        beatLeft.GetComponent<Beat>().Initialise(hexagonLeft.GetComponent<TargetHexagon>(), beatTravelTime, hitTolerance);
+        beatLeft.GetComponent<Beat>().Initialise(hexagonLeft.GetComponent<TargetHexagon>(), beatTravelTime, hitTolerance, beatQueueLeft);
 
         GameObject beatRight = Instantiate(beatPrefab, spawnPointRight.position, Quaternion.identity, transform);
         // Should be the same as parent's rotation otherwise it will be out of shape
         beatRight.transform.rotation = transform.rotation;
-        beatRight.GetComponent<Beat>().Initialise(hexagonRight.GetComponent<TargetHexagon>(), beatTravelTime, hitTolerance);
-
-        beats.Add(beatLeft.GetComponent<Beat>());
-        beats.Add(beatRight.GetComponent<Beat>());
+        beatRight.GetComponent<Beat>().Initialise(hexagonRight.GetComponent<TargetHexagon>(), beatTravelTime, hitTolerance, beatQueueRight);
+        
+        beatQueueLeft.Enqueue(beatLeft.GetComponent<Beat>());
+        beatQueueRight.Enqueue(beatRight.GetComponent<Beat>());
     }
 
     // Check for and remove beats that have been hit
     public bool HitOnBeat()
     {
-        float numBeatsHit = 0;
-        for (int i = beats.Count - 1; i >= 0; i--)
+        Beat beatLeft = beatQueueLeft.Peek();
+        Beat beatRight = beatQueueRight.Peek();
+        if (beatLeft.IsHittable() && beatRight.IsHittable())
         {
-            if (beats[i].IsHittable())
-            {
-                beats[i].OnHit();
-                beats.RemoveAt(i);
-
-                numBeatsHit++;
-                if (numBeatsHit >= 2) return true;
-            }
+            // If both beats are hittable, remove them from the queue
+            beatLeft.OnHit();
+            beatRight.OnHit();
+            return true;
         }
 
         return false;
     }
+
+
 }
 


### PR DESCRIPTION
Defined onTempo variable for music timeline, which enables on the update that spawns beat
Added isSyncable in enemy controller,  if enabled, the AttackState will only initiates attack if MusicTimeline.instance.onTempo is true.

Potential Issue:
The enemy attack is sync with spawning the beat not when the beat end, which maybe mismatching to player's tempo 
The enemy attack initiated on the beat. It may be better to initate before the beat. 
The enemy attack still appear not synced if the beat is too short