### PR TITLE
feat: implement beat logic and UI syncing with shifting bpm and pitch

### DIFF
--- a/Assets/Scriptable/Beat Settings - Enter Regulator.asset
+++ b/Assets/Scriptable/Beat Settings - Enter Regulator.asset
@@ -15,8 +15,8 @@ MonoBehaviour:
   bpm: 160
   thresholds:
   - result: 2
-    tolerance: 0.05
-  - result: 1
     tolerance: 0.1
+  - result: 1
+    tolerance: 1
   initialEmptyBeats: 6
   beatPattern: 00000001

--- a/Assets/Scripts/FMOD/ScriptMusicTimeline.cs
+++ b/Assets/Scripts/FMOD/ScriptMusicTimeline.cs
@@ -143,6 +143,7 @@ namespace Timeline
 
         private void Update()
         {
+            _beatHandler.Update(Time.deltaTime);
             // TODO: Need to move this to a proper code path when the level starts
             if (Input.GetMouseButtonDown(0))
             {
@@ -177,7 +178,11 @@ namespace Timeline
 
             float speedRatio = TempoSetting.GetRatio(mode);
             _speedRatio = speedRatio;
-            musicInstance.setParameterByName("MusicSpeed", speedRatio);
+            // musicInstance.setParameterByName("MusicSpeed", speedRatio);
+            musicInstance.setPitch(speedRatio);
+            
+            _beatHandler.OnTempoChanged(mode);
+            _beatSpawner.OnTempoChanged(mode);
         }
 
         // BeatEventCallback: This method is called each time a new beat occurs

--- a/Assets/Scripts/System/BeatHandler.cs
+++ b/Assets/Scripts/System/BeatHandler.cs
@@ -5,16 +5,19 @@ using UnityEngine;
 public class BeatHandler
 {
     private int _beat;
+    private float _currentBeat;
     private readonly float _beatInterval;
     private bool _started;
-    private float _startTime;
     private BeatSettings _settings;
 
     public int Beat => _beat;
-    public float BeatInterval => _beatInterval;
 
     // TODO: Use this in the level end screen possibly for stats?
     private readonly Dictionary<int, Grade> _processedBeats = new Dictionary<int, Grade>();
+
+    private TempoMode _currentMode = TempoMode.Default;
+    public float CurrentBeat => _currentBeat;
+    public float BeatInterval => _beatInterval / TempoSetting.GetRatio(_currentMode);
 
     public BeatHandler(BeatSettings settings)
     {
@@ -39,7 +42,6 @@ public class BeatHandler
     private void Start()
     {
         _started = true;
-        _startTime = Time.time;
     }
 
     public void OnBeat()
@@ -47,6 +49,22 @@ public class BeatHandler
         if (_beat == 0)
             Start();
         _beat += 1;
+        
+        // By resetting our current beat tracker to the beat of the track, we minimise the offset created
+        // by floating point imprecision and weird delta time silliness on Unity's end.
+        _currentBeat = _beat;
+    }
+
+    public void OnTempoChanged(TempoMode mode)
+    {
+        _currentMode = mode;
+    }
+
+    public void Update(float deltaTime)
+    {
+        if (!_started) return;
+
+        _currentBeat += BeatInterval * deltaTime;
     }
 
     /// <summary>
@@ -109,16 +127,13 @@ public class BeatHandler
         // Get the next possible beat in order to allow for early and late beats
         int beat = GetNearestBeat();
         if (beat == -1) return new BeatResult(beat, Grade.Failed);
+
+        // The key is that we calculate the difference in the beats, as opposed to elapsed time!
+        float beatDifference = Mathf.Abs(beat - _currentBeat);
         
-        // Get the expected beat time and compare it against the current time
-        // Do beat - 1 since beat 1 starts on 0
-        float expectedBeatTime = (beat - 1) * _beatInterval;
-        float currentTime = Time.time - _startTime;
-        
-        float timeDifference = Mathf.Abs(expectedBeatTime - currentTime);
         for (int i = 0; i < _settings.thresholds.Length; ++i)
         {
-            if (timeDifference <= _settings.thresholds[i].tolerance)
+            if (beatDifference <= _settings.thresholds[i].tolerance)
             {
                 return new BeatResult(beat, _settings.thresholds[i].result);
             }

--- a/Assets/Scripts/UI/Beat/BeatPopupItem.cs
+++ b/Assets/Scripts/UI/Beat/BeatPopupItem.cs
@@ -49,6 +49,21 @@ public class BeatPopupItem : MonoBehaviour
         _sequence.Play().OnComplete(Resolve);
     }
 
+    public void OnTempoChanged(TempoMode _, BeatHandler beatHandler)
+    {
+        float remainingBeat = _beat - beatHandler.CurrentBeat;
+        if (remainingBeat <= 0) return;
+
+        float travelTime = remainingBeat * beatHandler.BeatInterval;
+        
+        // If we have a remaining beat, then we want to adjust our time to travel
+        _sequence.Kill();
+        _sequence = DOTween.Sequence();
+        _sequence.Append(leftHexagon.Rect.DOAnchorPos(_leftTarget.anchoredPosition, travelTime).SetEase(Ease.Linear));
+        _sequence.Join(rightHexagon.Rect.DOAnchorPos(_rightTarget.anchoredPosition, travelTime).SetEase(Ease.Linear));
+        _sequence.Play().OnComplete(Resolve);
+    }
+
     private void Resolve()
     {
         _sequence.Kill();
@@ -105,5 +120,4 @@ public class BeatPopupItem : MonoBehaviour
             _spawner.ResolveBeat(_beat);
             Destroy(gameObject);
         });
-        
     }}

--- a/Assets/Scripts/UI/Beat/BeatSpawner.cs
+++ b/Assets/Scripts/UI/Beat/BeatSpawner.cs
@@ -6,10 +6,6 @@ public class BeatSpawner : MonoBehaviour
     private const int BEAT_PREFIX = 4;
     // The distance that a beat will travel in one second
     private const float BEAT_DISTANCE = 700f;
-    
-    // IMPORTANT! This is a magic number to offset any weird visual de-sync between the actual beat and the UI
-    // Note(Alex): In my findings, the UI seems to reach the center slightly too late.
-    private const float ANIMATION_OFFSET_TIME = -0.05f;
 
     [SerializeField] private RectTransform beatHolder;
     [SerializeField] private BeatPopupItem sampleBeatPopupItem;
@@ -35,7 +31,7 @@ public class BeatSpawner : MonoBehaviour
         if (!_beatHandler.IsBeat(beat)) return;
         
         // The time to target is the amount of beats we spawned ahead of time
-        float travelTime = _beatHandler.BeatInterval * BEAT_PREFIX + ANIMATION_OFFSET_TIME;
+        float travelTime = _beatHandler.BeatInterval * BEAT_PREFIX;
         float distance = BEAT_DISTANCE * travelTime;
 
         BeatPopupItem beatPopupItem = Instantiate(sampleBeatPopupItem, beatHolder);
@@ -50,6 +46,14 @@ public class BeatSpawner : MonoBehaviour
     public void OnBeat(int beat)
     {
         SpawnBeat(beat + BEAT_PREFIX);
+    }
+
+    public void OnTempoChanged(TempoMode mode)
+    {
+        foreach (KeyValuePair<int, BeatPopupItem> popupItem in _popupItems)
+        {
+            popupItem.Value.OnTempoChanged(mode, _beatHandler);
+        }
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/SelectionWheelManager.cs
+++ b/Assets/Scripts/UI/SelectionWheelManager.cs
@@ -9,8 +9,6 @@ using System.Collections.Generic;
 
 public class SelectionWheelManager : MonoBehaviour
 {
-
-    [SerializeField] private GameObject selectionWheel; // The UI wheel to display
     [SerializeField] private GameObject selectionWheelPanel; // The UI wheel to display
     [SerializeField] private string inputName = "Tape"; // Input name as defined in the Input Manager
     [SerializeField] private BatteryManager batteryManager;
@@ -32,8 +30,14 @@ public class SelectionWheelManager : MonoBehaviour
 
     void Awake() {
         selectionWheelPanel.transform.localScale = Vector3.zero;
-    }    
-    
+    }
+
+    private void Start()
+    {
+        // TODO: Hacky way of dependency injection without using singleton
+        TapeNotificationManager.Instance.Init(this);
+    }
+
     void Update()
     {
         if (PauseManager.IsPaused && (PauseMenuController.Instance.isPauseMenu || StartMenuManager.Instance.isStartMenu))
@@ -250,11 +254,17 @@ public class SelectionWheelManager : MonoBehaviour
 
     public void UseTape()
     {
+        // TODO: This looks like dangerous recursion
         if (batteryManager.UseBattery(batteryNeeded) && isWheelActive)
         {
             UseTape();
             ToggleWheel();
         }
+    }
+
+    public void OnTapeComplete()
+    {
+        MusicTimeline.instance.SetSpeed(TempoMode.Default);
     }
 }
 

--- a/Assets/Scripts/UI/TapeNotificationManager.cs
+++ b/Assets/Scripts/UI/TapeNotificationManager.cs
@@ -24,9 +24,16 @@ public class TapeNotificationManager : Singleton<TapeNotificationManager>
     private bool isFadingOut = false;
     private Vector2 initialPosition;
 
+    private SelectionWheelManager _selectionWheel;
+
     void Start()
     {
         initialPosition = uiGroup.anchoredPosition;
+    }
+
+    public void Init(SelectionWheelManager selectionWheel)
+    {
+        _selectionWheel = selectionWheel;
     }
 
     public void ActivateTapeUI(TapeType tape, float duration)
@@ -145,7 +152,7 @@ public class TapeNotificationManager : Singleton<TapeNotificationManager>
         ResetTapeNotification();
     }
 
-    public void ResetTapeNotification()
+    private void ResetTapeNotification()
     {
         uiGroup.anchoredPosition = initialPosition;
         canvasGroup.alpha = 0f;
@@ -153,6 +160,9 @@ public class TapeNotificationManager : Singleton<TapeNotificationManager>
         countdownRoutine = null;
         currentRoutine = null;
         isFadingOut = false;
+        
+        // Alert the selection wheel that we are finished
+        _selectionWheel.OnTapeComplete();
     }
 }
 


### PR DESCRIPTION
# Beat Syncing with Changing BPM

The entire solution revolves around keeping track of a `_currentBeat` float inside of BeatHandler.
- `_currentBeat` is set to `beat` on the OnBeat callback, making it synced with FMOD
- `_currentBeat` is incremented by delta time as well as the tempo multiplier

The key understanding here is that when you shift pitches at a certain time, the current beat that you are on **does not change**. E.g. if you are currently on beat 4 and you shift from 160 BPM to 140 BPM, **you are still on beat 4!** This means all that needs to change is your current tracking of the beat from then on.

The UI also gets a nice bump, recalculating its time to travel based on the remaining beat.

closes #90 

