### PR TITLE
fix: virtual camera not resetting 

### DIFF
--- a/Assets/Scenes/Level1/Room1.unity
+++ b/Assets/Scenes/Level1/Room1.unity
@@ -791,7 +791,7 @@ PrefabInstance:
       objectReference: {fileID: 124250380}
     - target: {fileID: 6680799956431943811, guid: b923e3abcc85ba24d87e2fa1c3f87a57, type: 3}
       propertyPath: initialActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6680799956431943811, guid: b923e3abcc85ba24d87e2fa1c3f87a57, type: 3}
       propertyPath: followOffset.x

--- a/Assets/Scripts/System/CameraManager.cs
+++ b/Assets/Scripts/System/CameraManager.cs
@@ -23,7 +23,14 @@ public class CameraManager : MonoBehaviour
     {
         cameras.Add(camera);
         camera.Priority = initialActive ? activePriority : inactivePriority;
-        if (initialActive) initialCamera = camera;
+        if (initialActive)
+        {
+            initialCamera = camera;
+        }
+        else
+        {
+            Debug.LogWarning($"Multiple cameras have initialActive = true! Pls deactivate Camera");
+        }
     }
 
     public void Delete(CinemachineVirtualCamera camera)


### PR DESCRIPTION
the issue is that in first room, 2 camera has the initialActive bool on , so the camera manager resets to the wrong camera. 
Added Warning if more than 1 camera has set initialActive to true.